### PR TITLE
raised PublicSuffix::DomainNotAllowed when domain assigned cctld with subdomain

### DIFF
--- a/lib/domain_validator_jp.rb
+++ b/lib/domain_validator_jp.rb
@@ -30,6 +30,8 @@ module DomainValidatorJp
 
     def parsed(domain)
       PublicSuffix.parse(domain)
+    rescue PublicSuffix::DomainNotAllowed
+      PublicSuffix::Domain.new(domain)   # set as TLD
     end
 
     # common

--- a/lib/domain_validator_jp/version.rb
+++ b/lib/domain_validator_jp/version.rb
@@ -1,3 +1,3 @@
 module DomainValidatorJp
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end

--- a/spec/domain_validator_jp_spec.rb
+++ b/spec/domain_validator_jp_spec.rb
@@ -98,6 +98,12 @@ RSpec.describe DomainValidatorJp do
 
           it { is_expected.to be_falsey }
         end
+
+        context 'domain equals cctld with subdomain' do
+          let(:domain) { 'co.uk' }
+
+          it { is_expected.to be_falsey }
+        end
       end
 
       describe 'multibyte' do


### PR DESCRIPTION
```
[2] pry(main)> DomainValidatorJp.valid?('co.uk')
PublicSuffix::DomainNotAllowed: `co.uk` is not allowed according to Registry policy
from /Users/hiromikimura/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/public_suffix-3.0.2/lib/public_suffix.rb:78:in `parse'
```