### PR TITLE
Occur error when private domain validation

### DIFF
--- a/lib/domain_validator_jp.rb
+++ b/lib/domain_validator_jp.rb
@@ -41,7 +41,7 @@ module DomainValidatorJp
     end
 
     def valid_public_suffix?(domain)
-      PublicSuffix.valid?(domain, default_rule: nil, ignore_private: true)
+      PublicSuffix.valid?(domain, default_rule: nil)
     end
 
     def valid_sld_not_dotted?(domain)

--- a/lib/domain_validator_jp.rb
+++ b/lib/domain_validator_jp.rb
@@ -5,6 +5,7 @@ module DomainValidatorJp
   class << self
     def valid?(domain)
       return false unless fqdn?(domain)
+      return false unless valid_sld_included?(domain)
       return false if include_subdomain?(domain)
       return false unless valid_public_suffix?(domain)
       return false unless valid_sld_not_dotted?(domain)
@@ -35,6 +36,10 @@ module DomainValidatorJp
     end
 
     # common
+
+    def valid_sld_included?(domain)
+      !!parsed(domain).sld
+    end
 
     def include_subdomain?(domain)
       !parsed(domain).subdomain.nil?

--- a/lib/domain_validator_jp/version.rb
+++ b/lib/domain_validator_jp/version.rb
@@ -1,3 +1,3 @@
 module DomainValidatorJp
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/spec/domain_validator_jp_spec.rb
+++ b/spec/domain_validator_jp_spec.rb
@@ -104,6 +104,12 @@ RSpec.describe DomainValidatorJp do
 
           it { is_expected.to be_falsey }
         end
+
+        context 'domain equals private domain' do
+          let(:domain) { 'blogspot.com' }
+
+          it { is_expected.to be_falsey }
+        end
       end
 
       describe 'multibyte' do


### PR DESCRIPTION
```
irb(main):001:0> require 'domain_validator_jp'
=> true
irb(main):002:0> DomainValidatorJp.valid?('blogspot.com')
Traceback (most recent call last):
        4: from /Users/hiromikimura/.rbenv/versions/2.5.0/bin/irb:11:in `<main>'
        3: from (irb):3
        2: from /Users/hiromikimura/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/domain_validator_jp-0.3.0/lib/domain_validator_jp.rb:15:in `valid?'
        1: from /Users/hiromikimura/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/domain_validator_jp-0.3.0/lib/domain_validator_jp.rb:66:in `valid_length_sld_multibyte?'
```